### PR TITLE
fix: rewind StringIO between key parse attempts and use .get() for optional password

### DIFF
--- a/src/component.py
+++ b/src/component.py
@@ -183,6 +183,7 @@ class Component(ComponentBase):
             try:
                 keyfile.seek(0)
                 pkey = paramiko.Ed25519Key.from_private_key(keyfile)
+                failed = False
             except (paramiko.SSHException, IndexError) as e:
                 logging.warning("Ed25519Key Private key invalid.")
                 raise e

--- a/src/component.py
+++ b/src/component.py
@@ -184,9 +184,9 @@ class Component(ComponentBase):
                 keyfile.seek(0)
                 pkey = paramiko.Ed25519Key.from_private_key(keyfile)
                 failed = False
-            except (paramiko.SSHException, IndexError) as e:
+            except (paramiko.SSHException, IndexError):
                 logging.warning("Ed25519Key Private key invalid.")
-                raise e
+                raise
         return pkey
 
     def _upload_file(self, input_file):

--- a/src/component.py
+++ b/src/component.py
@@ -93,7 +93,7 @@ class Component(ComponentBase):
         self.connect_to_server(port,
                                host,
                                params[KEY_USER],
-                               params[KEY_PASSWORD],
+                               params.get(KEY_PASSWORD),
                                pkey,
                                disabled_algorithms,
                                banner_timeout)
@@ -158,11 +158,12 @@ class Component(ComponentBase):
         try:
             pkey = paramiko.RSAKey.from_private_key(keyfile)
         except paramiko.SSHException:
-            logging.warning("RSS Private key invalid, trying DSS.")
+            logging.warning("RSA Private key invalid, trying DSS.")
             failed = True
         # DSS
         if failed:
             try:
+                keyfile.seek(0)
                 pkey = paramiko.DSSKey.from_private_key(keyfile)
                 failed = False
             except (paramiko.SSHException, IndexError):
@@ -171,6 +172,7 @@ class Component(ComponentBase):
         # ECDSAKey
         if failed:
             try:
+                keyfile.seek(0)
                 pkey = paramiko.ECDSAKey.from_private_key(keyfile)
                 failed = False
             except (paramiko.SSHException, IndexError):
@@ -179,6 +181,7 @@ class Component(ComponentBase):
         # Ed25519Key
         if failed:
             try:
+                keyfile.seek(0)
                 pkey = paramiko.Ed25519Key.from_private_key(keyfile)
             except (paramiko.SSHException, IndexError) as e:
                 logging.warning("Ed25519Key Private key invalid.")
@@ -243,7 +246,7 @@ class Component(ComponentBase):
             self.connect_to_server(port,
                                    host,
                                    params[KEY_USER],
-                                   params[KEY_PASSWORD],
+                                   params.get(KEY_PASSWORD),
                                    pkey,
                                    disabled_algorithms,
                                    banner_timeout)

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -9,12 +9,35 @@ from os import path
 from os.path import dirname
 
 import mock
+import paramiko
 from freezegun import freeze_time
 
-from src.component import Component
+from src.component import Component, UserException
 
 TEST_DIR = path.join(dirname(path.realpath(__file__)), 'test_data')
 TEST_DIR_TIMESTAMP = path.join(dirname(path.realpath(__file__)), 'test_data_timestamp')
+TEST_DIR_KEYONLY = path.join(dirname(path.realpath(__file__)), 'test_data_keyonly')
+
+# Throwaway keys generated only for these tests (never used against a real host).
+# They exercise the non-RSA fallback parsers, which only work because
+# _parse_private_key rewinds the buffer (keyfile.seek(0)) between attempts.
+ECDSA_PRIVATE_KEY = """-----BEGIN OPENSSH PRIVATE KEY-----
+b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAaAAAABNlY2RzYS
+1zaGEyLW5pc3RwMjU2AAAACG5pc3RwMjU2AAAAQQR2XDVndS3a75jo5q1gLgiGgEaNFjzv
+xBRefrMMmi1QGj6X3H0sPJ8BDdbm+bL+GaKj0fTBloC5SuMMqRW85ZDmAAAAsDeYOvI3mD
+ryAAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBHZcNWd1LdrvmOjm
+rWAuCIaARo0WPO/EFF5+swyaLVAaPpfcfSw8nwEN1ub5sv4ZoqPR9MGWgLlK4wypFbzlkO
+YAAAAgR9ooXptoDu1/tEVFP7id8kLguMCyewyqgOUNE2RtMZsAAAASdGhyb3dhd2F5LXRl
+c3Qta2V5AQIDBAUG
+-----END OPENSSH PRIVATE KEY-----"""
+
+ED25519_PRIVATE_KEY = """-----BEGIN OPENSSH PRIVATE KEY-----
+b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
+QyNTUxOQAAACAQtEzIY06QrD9dJunJ0qMhs1slG4pTMK7ilsoF3OYzmwAAAJjmoJLD5qCS
+wwAAAAtzc2gtZWQyNTUxOQAAACAQtEzIY06QrD9dJunJ0qMhs1slG4pTMK7ilsoF3OYzmw
+AAAEAHiBSJY4Gx4AxT3Z/T2QChbEAvBNLBBytxvJyBnBlCRxC0TMhjTpCsP10m6cnSoyGz
+WyUbilMwruKWygXc5jObAAAAEnRocm93YXdheS10ZXN0LWtleQECAw==
+-----END OPENSSH PRIVATE KEY-----"""
 
 
 class TestComponent(unittest.TestCase):
@@ -46,10 +69,10 @@ class TestComponent(unittest.TestCase):
         self.assertEqual(output_destination, "/path/test_2010-10-10-00:00:00.csv")
 
     def test_parse_private_key_throws_error_on_invalid_key(self):
-        with self.assertRaises(IndexError):
-            self.comp.get_private_key({"#private_key":"key"})
+        with self.assertRaises(UserException):
+            self.comp.get_private_key({"#private_key": "key"})
 
-    def test_parse_private_key_throws_error_on_invalid_key(self):
+    def test_parse_private_key_rsa(self):
         key = self.comp.get_private_key({"#private_key":
             "-----BEGIN RSA PRIVATE KEY-----\nMIIEogIBAAKCAQEAsH4Y5UUUCHiD7OkNEjHhZeqOnbIv2/Sr3jzz+DrkGvAlEGwT"
             "\n7btrqWuqZT/cX3x1B0wiMqu3zMC+78Gy5bdNau7BJpN5FjwAzzDKVArR47ZIlyKO\nKGhRvafq2pZGQh9YUYsECzA2yoJdJTMfc"
@@ -77,6 +100,31 @@ class TestComponent(unittest.TestCase):
     def test_get_private_key_with_none(self):
         key = self.comp.get_private_key({})
         self.assertEqual(key, None)
+
+    def test_parse_private_key_non_rsa_fallback(self):
+        # The RSA parser consumes the buffer; without the seek(0) rewind between
+        # attempts, these non-RSA keys would fail to parse. Guards that fix.
+        cases = [
+            (ECDSA_PRIVATE_KEY, paramiko.ECDSAKey),
+            (ED25519_PRIVATE_KEY, paramiko.Ed25519Key),
+        ]
+        for keystring, expected_type in cases:
+            with self.subTest(key_type=expected_type.__name__):
+                key = self.comp.get_private_key({"#private_key": keystring})
+                self.assertIsInstance(key, expected_type)
+
+    @mock.patch.dict(os.environ, {'KBC_DATADIR': TEST_DIR_KEYONLY})
+    @mock.patch.object(Component, 'connect_to_server')
+    def test_key_only_config_uses_none_password(self, mock_connect):
+        # A key-only config has no '#pass'; run()/test_connection() must not raise
+        # KeyError and must call connect_to_server with password=None (bug #2).
+        comp = Component()
+        comp.test_connection()
+        mock_connect.assert_called_once()
+        args = mock_connect.call_args.args
+        # signature: (port, host, user, password, pkey, disabled_algorithms, banner_timeout)
+        self.assertIsNone(args[3])
+        self.assertIsInstance(args[4], paramiko.ECDSAKey)
 
 
 if __name__ == "__main__":

--- a/tests/test_data_keyonly/config.json
+++ b/tests/test_data_keyonly/config.json
@@ -1,0 +1,10 @@
+{
+  "parameters": {
+    "port": 22,
+    "user": "fakeuser",
+    "hostname": "fakehost",
+    "#private_key": "-----BEGIN OPENSSH PRIVATE KEY-----\nb3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAaAAAABNlY2RzYS\n1zaGEyLW5pc3RwMjU2AAAACG5pc3RwMjU2AAAAQQR2XDVndS3a75jo5q1gLgiGgEaNFjzv\nxBRefrMMmi1QGj6X3H0sPJ8BDdbm+bL+GaKj0fTBloC5SuMMqRW85ZDmAAAAsDeYOvI3mD\nryAAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBHZcNWd1LdrvmOjm\nrWAuCIaARo0WPO/EFF5+swyaLVAaPpfcfSw8nwEN1ub5sv4ZoqPR9MGWgLlK4wypFbzlkO\nYAAAAgR9ooXptoDu1/tEVFP7id8kLguMCyewyqgOUNE2RtMZsAAAASdGhyb3dhd2F5LXRl\nc3Qta2V5AQIDBAUG\n-----END OPENSSH PRIVATE KEY-----",
+    "path": "/path/",
+    "append_date": "false"
+  }
+}


### PR DESCRIPTION
## Summary

Fixes two independent bugs in the private-key/password auth path ([SUPPORT-16829](https://keboola.atlassian.net/browse/SUPPORT-16829)):

**Bug 1 – Non-RSA private keys always fail (shared, non-rewound buffer)**

`_parse_private_key()` passes a single `StringIO` through four sequential parsers. paramiko's `from_private_key()` calls `readlines()` which moves the pointer to EOF. After the first (RSA) attempt fails, subsequent parsers (DSS → ECDSA → Ed25519) all see an empty buffer and raise `"no lines in … private key file"`.

```python
# Before: buffer consumed after RSA attempt, never rewound
pkey = paramiko.RSAKey.from_private_key(keyfile)   # reads to EOF
pkey = paramiko.DSSKey.from_private_key(keyfile)   # empty → fail

# After: seek(0) before each fallback attempt
keyfile.seek(0)
pkey = paramiko.DSSKey.from_private_key(keyfile)   # full buffer
```

**Bug 2 – `KeyError: '#pass'` when using key-only auth**

`run()` and `test_connection()` both do `params[KEY_PASSWORD]` which raises `KeyError` when `#pass` is absent (key-only configs pass validation since password is in an OR-group with `#private_key` and `ssh`).

```python
# Before
params[KEY_PASSWORD]          # KeyError if key-only auth

# After
params.get(KEY_PASSWORD)      # returns None; paramiko accepts password=None
```

Also fixed typo: `"RSS Private key invalid"` → `"RSA Private key invalid"`.

## Release Notes
**Justification, description**

Fixes two bugs preventing key-based SFTP authentication: (1) non-RSA keys (DSS/ECDSA/Ed25519) could never parse due to unrewound StringIO buffer, (2) key-only configs without a password caused `KeyError: '#pass'`.

**Plans for Customer Communication**

Customers affected by SUPPORT-16829 can retry their configurations after upgrade.

**Impact Analysis**

Minimal risk — `seek(0)` restores the previously-intended fallback behavior, and `.get()` returns `None` which paramiko already accepts for `password` when a `pkey` is supplied. RSA key path is unchanged.

**Deployment Plan**

Standard release via Developer Portal tag.

**Rollback Plan**

Revert to previous version (1.3.9) if needed.

**Post-Release Support Plan**

N/A

Link to Devin session: https://app.devin.ai/sessions/5d6e544ba786410cb0b88af31653e3b6
Requested by: @terezaskalova

[SUPPORT-16829]: https://keboola.atlassian.net/browse/SUPPORT-16829?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ